### PR TITLE
adding the image to the donation view as an image

### DIFF
--- a/app/Orchid/Screens/DonationEditScreen.php
+++ b/app/Orchid/Screens/DonationEditScreen.php
@@ -88,6 +88,7 @@ class DonationEditScreen extends Screen
              Layout::legend('donation', [
                 Sight::make('image')->render(function (Donation $donation) {
                     return "<img src={$donation['image']}
+                          alt='donation'
                           class='mw-50 d-block img-fluid'>";
                 }),
                 Sight::make('id')->popover('Numero identificativo de la donacion en el sistema'),
@@ -108,6 +109,7 @@ class DonationEditScreen extends Screen
             Layout::legend('donation.user', [
                 Sight::make('image')->render(function (User $user) {
                     return "<img src={$user['image']}
+                          alt='user'
                           class='mw-50 d-block img-fluid'>";
                 }),
                 Sight::make('id')->popover('Numero identificativo del usuario que creo la donacion en el sistema'),

--- a/app/Orchid/Screens/DonationEditScreen.php
+++ b/app/Orchid/Screens/DonationEditScreen.php
@@ -88,7 +88,7 @@ class DonationEditScreen extends Screen
              Layout::legend('donation', [
                 Sight::make('image')->render(function (Donation $donation) {
                     return "<img src={$donation['image']}
-                          alt='sample'
+                          alt='image-donation'
                           class='mw-50 d-block img-fluid'>";
                 }),
                 Sight::make('id')->popover('Numero identificativo de la donacion en el sistema'),
@@ -109,7 +109,7 @@ class DonationEditScreen extends Screen
             Layout::legend('donation.user', [
                 Sight::make('image')->render(function (User $user) {
                     return "<img src={$user['image']}
-                          alt='sample'
+                          alt='user-image'
                           class='mw-50 d-block img-fluid'>";
                 }),
                 Sight::make('id')->popover('Numero identificativo del usuario que creo la donacion en el sistema'),

--- a/app/Orchid/Screens/DonationEditScreen.php
+++ b/app/Orchid/Screens/DonationEditScreen.php
@@ -88,7 +88,6 @@ class DonationEditScreen extends Screen
              Layout::legend('donation', [
                 Sight::make('image')->render(function (Donation $donation) {
                     return "<img src={$donation['image']}
-                          alt='image-donation'
                           class='mw-50 d-block img-fluid'>";
                 }),
                 Sight::make('id')->popover('Numero identificativo de la donacion en el sistema'),
@@ -109,7 +108,6 @@ class DonationEditScreen extends Screen
             Layout::legend('donation.user', [
                 Sight::make('image')->render(function (User $user) {
                     return "<img src={$user['image']}
-                          alt='user-image'
                           class='mw-50 d-block img-fluid'>";
                 }),
                 Sight::make('id')->popover('Numero identificativo del usuario que creo la donacion en el sistema'),

--- a/app/Orchid/Screens/DonationEditScreen.php
+++ b/app/Orchid/Screens/DonationEditScreen.php
@@ -86,6 +86,11 @@ class DonationEditScreen extends Screen
     {
         return [
              Layout::legend('donation', [
+                Sight::make('image')->render(function (Donation $donation) {
+                    return "<img src={$donation['image']}
+                          alt='sample'
+                          class='mw-50 d-block img-fluid'>";
+                }),
                 Sight::make('id')->popover('Numero identificativo de la donacion en el sistema'),
                 Sight::make('name')->popover('Nombre de la donacion'),
                 Sight::make('description')->popover('Descripción de la donacion'),
@@ -102,6 +107,11 @@ class DonationEditScreen extends Screen
                     ->help('Cambia el estado de una donacion')
             ]),
             Layout::legend('donation.user', [
+                Sight::make('image')->render(function (User $user) {
+                    return "<img src={$user['image']}
+                          alt='sample'
+                          class='mw-50 d-block img-fluid'>";
+                }),
                 Sight::make('id')->popover('Numero identificativo del usuario que creo la donacion en el sistema'),
                 Sight::make('name')->popover('Nombre del usuario'),
                 Sight::make('email')->popover('Correo electronico del usuario'),


### PR DESCRIPTION
About :

This Pull Request add an image to the Donation View in the Admin Panel, insted of being an URL to be clicked there is an Image in the information.

Extra :

I also add the same logic to the User section in the Donation View.

Demo: 
![image](https://user-images.githubusercontent.com/56725406/151707761-7c791852-d3b3-4b42-8004-b7a4fbc81656.png)
![image](https://user-images.githubusercontent.com/56725406/151707792-3c4d3803-91c8-4cac-8ca0-a5c9959156d9.png)

